### PR TITLE
Use query from request in facet count

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can configure the search configuration string either in the VC Manager UI or
 * Sorting by geo distance (`GeoDistanceSortingField`) is not supported
 
 # License
-Copyright (c) Virtosoftware Ltd. All rights reserved.
+Copyright (c) Virto Solutions LTD. All rights reserved.
 
 Licensed under the Virto Commerce Open Software License (the "License"); you
 may not use this file except in compliance with the License. You may

--- a/VirtoCommerce.LuceneSearchModule.Data/LuceneSearchProvider.cs
+++ b/VirtoCommerce.LuceneSearchModule.Data/LuceneSearchProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -164,7 +164,7 @@ namespace VirtoCommerce.LuceneSearchModule.Data
                         ? searcher.Search(query, filter, count, sort)
                         : searcher.Search(query, filter, count);
 
-                    var result = providerResponse.ToSearchResponse(request, searcher, documentType, availableFields);
+                    var result = providerResponse.ToSearchResponse(request, searcher, documentType, availableFields, query);
                     return Task.FromResult(result);
                 }
             }


### PR DESCRIPTION
This passes down the query from the request to the CalculateFacetCount method so things like the keywords are respected when calculating the tag counts.