### PR TITLE
VP-1215 Fix search code by terms

### DIFF
--- a/src/VirtoCommerce.LuceneSearchModule.Data/LuceneSearchFilterBuilder.cs
+++ b/src/VirtoCommerce.LuceneSearchModule.Data/LuceneSearchFilterBuilder.cs
@@ -84,7 +84,8 @@ namespace VirtoCommerce.LuceneSearchModule.Data
             if (termFilter?.FieldName != null && termFilter.Values != null)
             {
                 var isBooleanField = availableFields.Contains(LuceneSearchHelper.GetBooleanFieldName(termFilter.FieldName));
-                var values = termFilter.Values.Select(v => GetFilterValue(v, isBooleanField)).ToArray();
+                var isStringField = string.Equals("code", termFilter.FieldName, StringComparison.InvariantCultureIgnoreCase);
+                var values = termFilter.Values.Select(v => GetFilterValue(v, isBooleanField, isStringField)).ToArray();
 
                 var fieldName = LuceneSearchHelper.ToLuceneFieldName(termFilter.FieldName);
                 result = CreateTermsFilter(fieldName, values);
@@ -264,12 +265,15 @@ namespace VirtoCommerce.LuceneSearchModule.Data
             return query;
         }
 
-        private static string GetFilterValue(string value, bool isBooleanField)
+        private static string GetFilterValue(string value, bool isBooleanField, bool isStringField)
         {
             if (string.IsNullOrEmpty(value))
             {
                 return string.Empty;
             }
+
+            if (isStringField)
+                return value;
 
             if (isBooleanField)
             {

--- a/tests/VirtoCommerce.LuceneSearchModule.Tests/SearchProviderTests.cs
+++ b/tests/VirtoCommerce.LuceneSearchModule.Tests/SearchProviderTests.cs
@@ -62,8 +62,8 @@ namespace VirtoCommerce.LuceneSearchModule.Tests
 
             var response = await provider.SearchAsync(DocumentType, request);
 
-            Assert.Equal(2, response.DocumentsCount);
-            Assert.Equal(6, response.TotalCount);
+            Assert.Equal(3, response.DocumentsCount);
+            Assert.Equal(7, response.TotalCount);
         }
 
         [Fact]
@@ -264,8 +264,27 @@ namespace VirtoCommerce.LuceneSearchModule.Tests
         {
             var provider = GetSearchProvider();
 
-            // Filtering by non-existent field name leads to empty result
+            // Filter by code with integer value
             var request = new SearchRequest
+            {
+                Filter = new TermFilter
+                {
+                    FieldName = "code",
+                    Values = new[]
+                    {
+                        "565567699"
+                    }
+                },
+                Take = 10,
+            };
+
+            var response = await provider.SearchAsync(DocumentType, request);
+
+            Assert.Equal(1, response.DocumentsCount);
+
+
+            // Filtering by non-existent field name leads to empty result
+            request = new SearchRequest
             {
                 Filter = new TermFilter
                 {
@@ -275,7 +294,7 @@ namespace VirtoCommerce.LuceneSearchModule.Tests
                 Take = 10,
             };
 
-            var response = await provider.SearchAsync(DocumentType, request);
+            response = await provider.SearchAsync(DocumentType, request);
 
             Assert.Equal(0, response.DocumentsCount);
 
@@ -378,6 +397,8 @@ namespace VirtoCommerce.LuceneSearchModule.Tests
             response = await provider.SearchAsync(DocumentType, request);
 
             Assert.Equal(2, response.DocumentsCount);
+
+
         }
 
         [Fact]
@@ -413,7 +434,7 @@ namespace VirtoCommerce.LuceneSearchModule.Tests
 
             response = await provider.SearchAsync(DocumentType, request);
 
-            Assert.Equal(4, response.DocumentsCount);
+            Assert.Equal(5, response.DocumentsCount);
         }
 
 
@@ -493,11 +514,11 @@ namespace VirtoCommerce.LuceneSearchModule.Tests
 
             criteria = new SearchRequest { Take = 0, Filter = CreateRangeFilter("Date", "2017-04-23T15:24:31.180Z", null, true, false) };
             response = await provider.SearchAsync(DocumentType, criteria);
-            Assert.Equal(6, response.TotalCount);
+            Assert.Equal(7, response.TotalCount);
 
             criteria = new SearchRequest { Take = 0, Filter = CreateRangeFilter("Date", "2017-04-23T15:24:31.180Z", null, false, false) };
             response = await provider.SearchAsync(DocumentType, criteria);
-            Assert.Equal(5, response.TotalCount);
+            Assert.Equal(6, response.TotalCount);
         }
 
         [Fact]
@@ -546,7 +567,7 @@ namespace VirtoCommerce.LuceneSearchModule.Tests
 
             var response = await provider.SearchAsync(DocumentType, request);
 
-            Assert.Equal(4, response.DocumentsCount);
+            Assert.Equal(5, response.DocumentsCount);
 
 
             request = new SearchRequest
@@ -568,7 +589,7 @@ namespace VirtoCommerce.LuceneSearchModule.Tests
 
             response = await provider.SearchAsync(DocumentType, request);
 
-            Assert.Equal(2, response.DocumentsCount);
+            Assert.Equal(3, response.DocumentsCount);
         }
 
         [Fact]
@@ -646,7 +667,7 @@ namespace VirtoCommerce.LuceneSearchModule.Tests
 
             var response = await provider.SearchAsync(DocumentType, request);
 
-            Assert.Equal(4, response.DocumentsCount);
+            Assert.Equal(5, response.DocumentsCount);
         }
 
         [Fact]
@@ -795,7 +816,7 @@ namespace VirtoCommerce.LuceneSearchModule.Tests
             Assert.Equal(0, response.DocumentsCount);
             Assert.Equal(1, response.Aggregations?.Count);
 
-            Assert.Equal(4, GetAggregationValuesCount(response, "Color"));
+            Assert.Equal(5, GetAggregationValuesCount(response, "Color"));
             Assert.Equal(3, GetAggregationValueCount(response, "Color", "Red"));
             Assert.Equal(1, GetAggregationValueCount(response, "Color", "Black"));
             Assert.Equal(1, GetAggregationValueCount(response, "Color", "Blue"));
@@ -821,7 +842,7 @@ namespace VirtoCommerce.LuceneSearchModule.Tests
             Assert.Equal(0, response.DocumentsCount);
             Assert.Equal(1, response.Aggregations?.Count);
 
-            Assert.Equal(5, GetAggregationValuesCount(response, "Size"));
+            Assert.Equal(6, GetAggregationValuesCount(response, "Size"));
             Assert.Equal(1, GetAggregationValueCount(response, "Size", "2"));
             Assert.Equal(1, GetAggregationValueCount(response, "Size", "3"));
             Assert.Equal(1, GetAggregationValueCount(response, "Size", "4"));

--- a/tests/VirtoCommerce.LuceneSearchModule.Tests/SearchProviderTestsBase.cs
+++ b/tests/VirtoCommerce.LuceneSearchModule.Tests/SearchProviderTestsBase.cs
@@ -23,6 +23,7 @@ namespace VirtoCommerce.LuceneSearchModule.Tests
                 CreateDocument("Item-3", "Red Shirt", "Red", "2017-04-26T15:24:31.180Z", 3, "0,20", null, null, new Price("USD", "default", 10m)),
                 CreateDocument("Item-4", "Black Sox", "Black", "2017-04-25T15:24:31.180Z", 10, "0,30", null, null, new Price("USD", "default", 243.12m), new Price("USD", "supersale", 89m)),
                 CreateDocument("Item-5", "Black Sox2", "Silver", "2017-04-24T15:24:31.180Z", 20, "0,40", null, null, new Price("USD", "default", 700m)),
+                CreateDocument("565567699", "Green Sox", "Green", "2020-07-21T15:24:31.180Z", 30, "0,40", null, null, new Price("USD", "default", 900m)),
             };
         }
 


### PR DESCRIPTION
### Problem
Could not find product by terms and code property if product code is numeric. Ex: 565567699. "code:565567699"

### Proposed of changes
Extend Filter converter with predefined string properties.

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
