### PR TITLE
Lucene search engine in-memory mode support (for automated testing)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(dotnet build:*)",
+      "Bash(dotnet test:*)"
+    ]
+  }
+}

--- a/src/VirtoCommerce.LuceneSearchModule.Data/LuceneSearchOptions.cs
+++ b/src/VirtoCommerce.LuceneSearchModule.Data/LuceneSearchOptions.cs
@@ -1,10 +1,16 @@
-using System.ComponentModel.DataAnnotations;
+namespace VirtoCommerce.LuceneSearchModule.Data;
 
-namespace VirtoCommerce.LuceneSearchModule.Data
+public class LuceneSearchOptions
 {
-    public class LuceneSearchOptions
-    {
-        [Required]
-        public string Path { get; set; }
-    }
+    /// <summary>
+    /// Path to the directory where Lucene indices are stored.
+    /// Required when UseInMemory is false.
+    /// </summary>
+    public string Path { get; set; }
+
+    /// <summary>
+    /// When true, uses in-memory RAMDirectory instead of FSDirectory.
+    /// Useful for testing purposes. Default is false.
+    /// </summary>
+    public bool UseInMemory { get; set; }
 }

--- a/src/VirtoCommerce.LuceneSearchModule.Data/LuceneSearchProvider.cs
+++ b/src/VirtoCommerce.LuceneSearchModule.Data/LuceneSearchProvider.cs
@@ -125,48 +125,51 @@ namespace VirtoCommerce.LuceneSearchModule.Data
 
             var indexName = GetIndexName(documentType);
 
-            CloseWriter(indexName, false);
-
-            Analyzer analyzer = new StandardAnalyzer(LuceneVersion.LUCENE_48);
-            var config = new IndexWriterConfig(LuceneVersion.LUCENE_48, analyzer);
-
-            var directory = GetDirectory(indexName);
-            try
+            lock (_providerLock)
             {
-                using (var writer = new IndexWriter(directory, config))
-                {
-                    foreach (var document in documents)
-                    {
-                        var resultItem = new IndexingResultItem { Id = document.Id };
-                        result.Items.Add(resultItem);
+                CloseWriter(indexName, false);
 
-                        try
+                Analyzer analyzer = new StandardAnalyzer(LuceneVersion.LUCENE_48);
+                var config = new IndexWriterConfig(LuceneVersion.LUCENE_48, analyzer);
+
+                var directory = GetDirectory(indexName);
+                try
+                {
+                    using (var writer = new IndexWriter(directory, config))
+                    {
+                        foreach (var document in documents)
                         {
-                            if (!string.IsNullOrEmpty(document.Id))
+                            var resultItem = new IndexingResultItem { Id = document.Id };
+                            result.Items.Add(resultItem);
+
+                            try
                             {
-                                var trackingWriter = new TrackingIndexWriter(writer);
-                                var term = new Term(LuceneSearchHelper.KeyFieldName, document.Id);
-                                var deleteResult = trackingWriter.DeleteDocuments(new TermQuery(term));
-                                resultItem.Succeeded = deleteResult == 1;
+                                if (!string.IsNullOrEmpty(document.Id))
+                                {
+                                    var trackingWriter = new TrackingIndexWriter(writer);
+                                    var term = new Term(LuceneSearchHelper.KeyFieldName, document.Id);
+                                    var deleteResult = trackingWriter.DeleteDocuments(new TermQuery(term));
+                                    resultItem.Succeeded = deleteResult == 1;
+                                }
+                                else
+                                {
+                                    resultItem.ErrorMessage = "Document ID is empty";
+                                }
                             }
-                            else
+                            catch (Exception ex)
                             {
-                                resultItem.ErrorMessage = "Document ID is empty";
+                                resultItem.ErrorMessage = ex.ToString();
                             }
-                        }
-                        catch (Exception ex)
-                        {
-                            resultItem.ErrorMessage = ex.ToString();
                         }
                     }
                 }
-            }
-            finally
-            {
-                // Only dispose FSDirectory; RAMDirectory must be kept alive
-                if (!_luceneSearchOptions.UseInMemory)
+                finally
                 {
-                    directory?.Dispose();
+                    // Only dispose FSDirectory; RAMDirectory must be kept alive
+                    if (!_luceneSearchOptions.UseInMemory)
+                    {
+                        directory?.Dispose();
+                    }
                 }
             }
 
@@ -388,6 +391,11 @@ namespace VirtoCommerce.LuceneSearchModule.Data
 
         protected virtual string GetDirectoryPath(string indexName)
         {
+            if (string.IsNullOrEmpty(_luceneSearchOptions.Path))
+            {
+                throw new InvalidOperationException("LuceneSearchOptions.Path must be configured when UseInMemory is false.");
+            }
+
             return Path.Combine(_luceneSearchOptions.Path, indexName);
         }
 

--- a/tests/VirtoCommerce.LuceneSearchModule.Tests/LuceneInMemorySearchTests.cs
+++ b/tests/VirtoCommerce.LuceneSearchModule.Tests/LuceneInMemorySearchTests.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.Options;
+using VirtoCommerce.LuceneSearchModule.Data;
+using VirtoCommerce.SearchModule.Core.Model;
+using VirtoCommerce.SearchModule.Core.Services;
+using Xunit;
+
+namespace VirtoCommerce.LuceneSearchModule.Tests
+{
+    [Trait("Category", "CI")]
+    [Trait("Category", "IntegrationTest")]
+    public class LuceneInMemorySearchTests : SearchProviderTests
+    {
+        private static readonly ISearchProvider _sharedProvider = CreateProvider();
+
+        private static ISearchProvider CreateProvider()
+        {
+            var luceneOptions = Options.Create(new LuceneSearchOptions { UseInMemory = true });
+            var searchOptions = Options.Create(new SearchOptions { Scope = "test-core", Provider = "Lucene" });
+            return new LuceneSearchProvider(luceneOptions, searchOptions);
+        }
+
+        protected override ISearchProvider GetSearchProvider()
+        {
+            return _sharedProvider;
+        }
+    }
+}


### PR DESCRIPTION
## Description
This change introduces the 'UseInMemory' setting for the Lucene search provider.

Usage example:
```
        services.AddSingleton<ISearchProvider>(_ =>
        {
            var luceneOptions = Options.Create(new LuceneSearchOptions { UseInMemory = true });
            var searchOptions = Options.Create(new SearchOptions { Provider = "Lucene", Scope = "test" });
            return new LuceneSearchProvider(luceneOptions, searchOptions);
        });
```

In-memory mode is intended for automated testing purposes only, and should not be used in development or production environments.

The possibility of using in-memory search indexes together with in-memory SQLite database for E2E test automation (e.g. via Playwright) or quick local startup (e.g., running the Platform without installing a database or Elasticsearch for a quick run-check-and-forget scenario) is under consideration.

## References
### QA-test:
### Jira-link:
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.LuceneSearch_3.1002.0-pr-37-a3f1.zip