### PR TITLE
VCST-4687: Filters without values should be ignored

### DIFF
--- a/src/VirtoCommerce.LuceneSearchModule.Data/LuceneSearchFilterBuilder.cs
+++ b/src/VirtoCommerce.LuceneSearchModule.Data/LuceneSearchFilterBuilder.cs
@@ -69,7 +69,7 @@ namespace VirtoCommerce.LuceneSearchModule.Data
         {
             Filter result = null;
 
-            if (idsFilter?.Values != null)
+            if (idsFilter?.Values?.Count > 0)
             {
                 result = CreateTermsFilter(LuceneSearchHelper.KeyFieldName, idsFilter.Values);
             }
@@ -81,7 +81,7 @@ namespace VirtoCommerce.LuceneSearchModule.Data
         {
             Filter result = null;
 
-            if (termFilter?.FieldName != null && termFilter.Values != null)
+            if (termFilter?.FieldName != null && termFilter.Values?.Count > 0)
             {
                 var fieldName = LuceneSearchHelper.ToLuceneFieldName(termFilter.FieldName);
 
@@ -96,7 +96,7 @@ namespace VirtoCommerce.LuceneSearchModule.Data
         {
             Filter result = null;
 
-            if (rangeFilter?.FieldName != null && rangeFilter.Values != null)
+            if (rangeFilter?.FieldName != null && rangeFilter.Values?.Count > 0)
             {
                 var fieldName = LuceneSearchHelper.ToLuceneFieldName(rangeFilter.FieldName);
 

--- a/tests/VirtoCommerce.LuceneSearchModule.Tests/PriorityTestCaseOrderer.cs
+++ b/tests/VirtoCommerce.LuceneSearchModule.Tests/PriorityTestCaseOrderer.cs
@@ -8,8 +8,8 @@ namespace VirtoCommerce.LuceneSearchModule.Tests
 {
     public class PriorityTestCaseOrderer : ITestCaseOrderer
     {
-        public const string TypeName = "VirtoCommerce.SearchModule.Tests.PriorityTestCaseOrderer";
-        public const string AssembyName = "VirtoCommerce.SearchModule.Tests";
+        public const string TypeName = "VirtoCommerce.LuceneSearchModule.Tests.PriorityTestCaseOrderer";
+        public const string AssemblyName = "VirtoCommerce.LuceneSearchModule.Tests";
 
         public IEnumerable<TTestCase> OrderTestCases<TTestCase>(IEnumerable<TTestCase> testCases)
             where TTestCase : ITestCase

--- a/tests/VirtoCommerce.LuceneSearchModule.Tests/SearchProviderTests.cs
+++ b/tests/VirtoCommerce.LuceneSearchModule.Tests/SearchProviderTests.cs
@@ -8,7 +8,7 @@ using static VirtoCommerce.SearchModule.Core.Extensions.IndexDocumentExtensions;
 
 namespace VirtoCommerce.LuceneSearchModule.Tests
 {
-    [TestCaseOrderer(PriorityTestCaseOrderer.TypeName, PriorityTestCaseOrderer.AssembyName)]
+    [TestCaseOrderer(PriorityTestCaseOrderer.TypeName, PriorityTestCaseOrderer.AssemblyName)]
     [Trait("Category", "IntegrationTest")]
     public abstract class SearchProviderTests : SearchProviderTestsBase
     {
@@ -23,7 +23,7 @@ namespace VirtoCommerce.LuceneSearchModule.Tests
             provider.IndexAsync(DocumentType, GetSecondaryDocuments()).GetAwaiter().GetResult();
         }
 
-        [Fact]
+        [Fact, Priority(100)]
         public virtual async Task CanAddAndRemoveDocuments()
         {
             // Arrange
@@ -299,6 +299,84 @@ namespace VirtoCommerce.LuceneSearchModule.Tests
 
             // Assert
             Assert.Equal(2, response.DocumentsCount);
+        }
+
+        [Fact]
+        public virtual async Task IdsFilterWithoutValues_ShouldBeIgnored()
+        {
+            // Arrange
+            var provider = GetSearchProvider();
+
+            var request1 = new SearchRequest
+            {
+                Take = 10,
+            };
+
+            var request2 = new SearchRequest
+            {
+                Take = 10,
+                Filter = new IdsFilter { Values = [] },
+            };
+
+            // Act
+            var response1 = await provider.SearchAsync(DocumentType, request1);
+            var response2 = await provider.SearchAsync(DocumentType, request2);
+
+            // Assert
+            Assert.True(response1.DocumentsCount > 0);
+            Assert.Equal(response1.DocumentsCount, response2.DocumentsCount);
+        }
+
+        [Fact]
+        public virtual async Task TermFilterWithoutValues_ShouldBeIgnored()
+        {
+            // Arrange
+            var provider = GetSearchProvider();
+
+            var request1 = new SearchRequest
+            {
+                Take = 10,
+            };
+
+            var request2 = new SearchRequest
+            {
+                Take = 10,
+                Filter = new TermFilter { FieldName = "Code", Values = [] },
+            };
+
+            // Act
+            var response1 = await provider.SearchAsync(DocumentType, request1);
+            var response2 = await provider.SearchAsync(DocumentType, request2);
+
+            // Assert
+            Assert.True(response1.DocumentsCount > 0);
+            Assert.Equal(response1.DocumentsCount, response2.DocumentsCount);
+        }
+
+        [Fact]
+        public virtual async Task RangeFilterWithoutValues_ShouldBeIgnored()
+        {
+            // Arrange
+            var provider = GetSearchProvider();
+
+            var request1 = new SearchRequest
+            {
+                Take = 10,
+            };
+
+            var request2 = new SearchRequest
+            {
+                Take = 10,
+                Filter = new RangeFilter { FieldName = "Size", Values = [] },
+            };
+
+            // Act
+            var response1 = await provider.SearchAsync(DocumentType, request1);
+            var response2 = await provider.SearchAsync(DocumentType, request2);
+
+            // Assert
+            Assert.True(response1.DocumentsCount > 0);
+            Assert.Equal(response1.DocumentsCount, response2.DocumentsCount);
         }
 
         [Fact]


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4687
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.LuceneSearch_3.1001.0-pr-39-f1d4.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small guard-condition changes in filter construction plus added integration tests; behavior only changes for empty filter value lists.
> 
> **Overview**
> Updates Lucene filter building so `IdsFilter`, `TermFilter`, and `RangeFilter` are **ignored when `Values` is empty**, preventing creation of no-op/invalid Lucene filters.
> 
> Fixes test ordering metadata (`PriorityTestCaseOrderer` constants and `TestCaseOrderer` attribute) and adds integration tests asserting searches with empty-value filters return the same results as unfiltered searches; also prioritizes `CanAddAndRemoveDocuments` via `Priority(100)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1d460b65e33dc3c348040c49399201276fe7e04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->