### PR TITLE
VCST-5163: Stable 15 — LuceneSearch (platform 3.1039.0)

### DIFF
--- a/src/VirtoCommerce.LuceneSearchModule.Data/VirtoCommerce.LuceneSearchModule.Data.csproj
+++ b/src/VirtoCommerce.LuceneSearchModule.Data/VirtoCommerce.LuceneSearchModule.Data.csproj
@@ -17,6 +17,6 @@
     <PackageReference Include="Lucene.Net.Analysis.Common" Version="4.8.0-beta00017" />
     <PackageReference Include="Lucene.Net.QueryParser" Version="4.8.0-beta00017" />
     <PackageReference Include="Lucene.Net.Spatial" Version="4.8.0-beta00017" />
-    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1004.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.LuceneSearchModule.Web/module.manifest
+++ b/src/VirtoCommerce.LuceneSearchModule.Web/module.manifest
@@ -4,9 +4,9 @@
   <version>3.1004.0</version>
   <version-tag />
 
-  <platformVersion>3.1002.0</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Search" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Search" version="3.1004.0" />
   </dependencies>
 
   <title>Lucene Search</title>


### PR DESCRIPTION
Part of **Stable 15** (Wave 2). Builds against published platform [3.1039.0](https://github.com/VirtoCommerce/vc-platform/releases/tag/3.1039.0) + Wave-1 packages on nuget.org. Version is left for CI to increment at release.

- Platform -> **3.1039.0**; Wave-1 deps -> released versions.
- `vc-build Compress` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest and NuGet reference updates only; no runtime or search implementation changes.
> 
> **Overview**
> **Stable 15 / Wave 2** alignment for the Lucene Search module: no application or search logic changes, only version pins.
> 
> The data project now references **`VirtoCommerce.SearchModule.Core` 3.1004.0** (was 3.1000.0). **`module.manifest`** sets **`platformVersion` to 3.1039.0** (was 3.1002.0) and the **`VirtoCommerce.Search` module dependency to 3.1004.0** (was 3.1000.0), matching published platform and Wave-1 Search packages on NuGet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a56ef3fae6ad93d800710a9a0859c0538dcf77d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5163
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.LuceneSearch_3.1004.0-pr-40-7a56.zip